### PR TITLE
feat: add onboarding page to create organization on account creation

### DIFF
--- a/src/BitFinance.API/Controllers/IdentityController.cs
+++ b/src/BitFinance.API/Controllers/IdentityController.cs
@@ -1,27 +1,123 @@
 using System.Security.Claims;
 using Asp.Versioning;
 using BitFinance.API.InputModels;
+using BitFinance.API.Models.Request;
 using BitFinance.API.Services.Interfaces;
 using BitFinance.API.ViewModels;
+using BitFinance.Business.Entities;
+using BitFinance.Business.Interfaces;
 using BitFinance.Data.Repositories.Interfaces;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BitFinance.API.Controllers;
 
 [ApiController]
-[Authorize]
 [ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/identity")]
 public class IdentityController : ControllerBase
 {
     private readonly IUsersService _usersService;
+    private readonly UserManager<User> _userManager;
+    private readonly SignInManager<User> _signInManager;
+    private readonly ITokenService _tokenService;
+    private readonly ILogger<IdentityController> _logger;
+    private readonly IConfiguration _configuration;
 
-    public IdentityController(IUsersService usersService)
+    public IdentityController(IUsersService usersService, UserManager<User> userManager, SignInManager<User> signInManager, ILogger<IdentityController> logger, ITokenService tokenService, IConfiguration configuration)
     {
         _usersService = usersService;
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _logger = logger;
+        _tokenService = tokenService;
+        _configuration = configuration;
+    }
+    
+    [HttpPost("register")]
+    public async Task<IActionResult> RegisterAsync([FromBody] RegisterInputModel model)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+
+        var user = new User
+        {
+            UserName = model.Email,
+            Email = model.Email,
+            FirstName = model.FirstName,
+            LastName = model.LastName
+        };
+        
+        var result = await _userManager.CreateAsync(user, model.Password);
+        
+        if (result.Succeeded)
+        {
+            _logger.LogInformation("User created a new account with password");
+            
+            await _signInManager.SignInAsync(user, isPersistent: false);
+            
+            var token = _tokenService.GenerateToken(user);
+            
+            return Ok(new
+            {
+                accessToken = token,
+                expiresIn = DateTime.UtcNow.AddMinutes(
+                    Convert.ToInt32(_configuration["Jwt:ExpirationInMinutes"])),
+                user = new
+                {
+                    id = user.Id,
+                    email = user.Email,
+                    userName = user.UserName
+                }
+            });
+        }
+        
+        return BadRequest(new { Errors = result.Errors });
     }
 
+    [HttpPost("login")]
+    public async Task<IActionResult> LogInAsync([FromBody] LoginInputModel model)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+        
+        var user = await _userManager.FindByEmailAsync(model.Email);
+        
+        if (user == null)
+            return Unauthorized(new { message = "Invalid email or password" });
+        
+        var result = await _signInManager.PasswordSignInAsync(user, model.Password, false, lockoutOnFailure: true);
+        
+        if (result.Succeeded)
+        {
+            _logger.LogInformation("User logged in: {Email}", model.Email);
+        
+            var token = _tokenService.GenerateToken(user);
+        
+            return Ok(new
+            {
+                accessToken = token,
+                expiresIn = DateTime.UtcNow.AddMinutes(Convert.ToInt32(_configuration["Jwt:ExpirationInMinutes"])),
+                user = new
+                {
+                    id = user.Id,
+                    email = user.Email,
+                    userName = user.UserName
+                }
+            });
+        }
+    
+        if (result.IsLockedOut)
+        {
+            _logger.LogWarning("User account locked out: {Email}", model.Email);
+            return StatusCode(StatusCodes.Status403Forbidden, new { message = "Account locked out" });
+        }
+    
+        return Unauthorized(new { message = "Invalid email or password" });
+    }
+    
+    [Authorize]
     [HttpGet("me")]
     public async Task<IActionResult> GetMe()
     {
@@ -39,6 +135,7 @@ public class IdentityController : ControllerBase
         return Ok(new UserViewModel(user.Id, user.FullName, user?.Email ?? string.Empty, ReplaceUserName(user?.UserName), organizations));
     }
 
+    [Authorize]
     [HttpPost("manage/profile")]
     public async Task<IActionResult> UpdateProfile([FromBody] UpdateProfileInputModel model)
     {
@@ -60,7 +157,7 @@ public class IdentityController : ControllerBase
 
         return Ok(new UserViewModel(user.Id, user.FullName, user.Email ?? string.Empty, ReplaceUserName(user?.UserName), organizations));
     }
-
+    
     private static string ReplaceUserName(string? email)
     {
         return string.IsNullOrEmpty(email) ? string.Empty : email.Split('@')[0];

--- a/src/BitFinance.API/InputModels/LoginInputModel.cs
+++ b/src/BitFinance.API/InputModels/LoginInputModel.cs
@@ -1,0 +1,3 @@
+namespace BitFinance.API.InputModels;
+
+public record LoginInputModel(string Email, string Password);

--- a/src/BitFinance.API/InputModels/RegisterInputModel.cs
+++ b/src/BitFinance.API/InputModels/RegisterInputModel.cs
@@ -1,0 +1,3 @@
+namespace BitFinance.API.InputModels;
+
+public record RegisterInputModel(string FirstName, string LastName, string Email, string Password, string ConfirmPassword);

--- a/src/BitFinance.API/Services/TokenService.cs
+++ b/src/BitFinance.API/Services/TokenService.cs
@@ -1,0 +1,35 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using BitFinance.Business.Entities;
+using BitFinance.Business.Interfaces;
+using Microsoft.IdentityModel.Tokens;
+
+namespace BitFinance.API.Services;
+
+public class TokenService(IConfiguration configuration) : ITokenService
+{
+    public string GenerateToken(User user)
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["Jwt:Key"]));
+        var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, user.Id),
+            new Claim(JwtRegisteredClaimNames.Email, user.Email),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new Claim(ClaimTypes.NameIdentifier, user.Id)
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: configuration["Jwt:Issuer"],
+            audience: configuration["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(Convert.ToInt32(configuration["Jwt:ExpirationInMinutes"])),
+            signingCredentials: credentials
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/src/BitFinance.API/appsettings.json
+++ b/src/BitFinance.API/appsettings.json
@@ -4,9 +4,11 @@
     "Database": "",
     "Cache": ""
   },
-  "Auth0": {
-    "Authority": "",
-    "Audience": ""
+  "Jwt": {
+    "Key": "secret-key-with-at-least-256-bits",
+    "Issuer": "",
+    "Audience": "",
+    "ExpirationInMinutes": 120
   },
   "Serilog":  {
     "MinimumLevel": {
@@ -16,9 +18,6 @@
         "System": "Warning"
       }
     }
-  },
-  "ElasticSearch": {
-    "Uri": "http://localhost:9200"
   },
   "AllowedHosts": "*"
 }

--- a/src/BitFinance.Business/Interfaces/ITokenService.cs
+++ b/src/BitFinance.Business/Interfaces/ITokenService.cs
@@ -1,0 +1,8 @@
+using BitFinance.Business.Entities;
+
+namespace BitFinance.Business.Interfaces;
+
+public interface ITokenService
+{
+    string GenerateToken(User user);
+}


### PR DESCRIPTION
- Adds a page to allow organization creation when user signs up
- Refactors identity endpoints to automatically login user after sign up and set name when registering a new account