### PR TITLE
feat: add S3-backed bill document storage + delete endpoint

### DIFF
--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,4 +1,4 @@
-﻿**/.dockerignore
+**/.dockerignore
 **/.env
 **/.git
 **/.gitignore

--- a/src/BitFinance.API/BitFinance.API.csproj
+++ b/src/BitFinance.API/BitFinance.API.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
         <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+        <PackageReference Include="AWSSDK.S3" Version="4.0.18.6" />
         <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
         <PackageReference Include="Azure.Identity" Version="1.15.0" />
         <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />

--- a/src/BitFinance.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BitFinance.API/Extensions/ServiceCollectionExtensions.cs
@@ -1,17 +1,20 @@
+using Amazon.S3;
 using BitFinance.API.Middlewares;
 using BitFinance.API.Services;
 using BitFinance.API.Services.Interfaces;
+using BitFinance.API.Settings;
 using BitFinance.Business.Interfaces;
 using BitFinance.Data.Caching;
 using BitFinance.Data.Repositories;
 using BitFinance.Data.Repositories.Interfaces;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
 
 namespace BitFinance.API.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddDependencyInjection(this IServiceCollection services)
+    public static IServiceCollection AddDependencyInjection(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddHostedService<BillStatusWorkerService>();
         services.AddHostedService<RefreshTokenCleanupService>();
@@ -27,14 +30,38 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IBillsService, BillsService>();
         services.AddScoped<IExpensesService, ExpensesService>();
         services.AddScoped<ITokenService, TokenService>();
-        services.AddScoped<IFileStorageService, LocalFileStorageService>();
         services.AddScoped<IFileValidationService, FileValidationService>();
         services.AddScoped<IBillDocumentService, BillDocumentService>();
         services.AddScoped<ICookieService, CookieService>();
 
+        services.AddSingleton<IValidateOptions<StorageSettings>, StorageSettingsValidator>();
+        services.AddOptions<StorageSettings>()
+            .Bind(configuration.GetSection(StorageSettings.SectionName))
+            .ValidateOnStart();
+        services.AddFileStorageProvider(configuration);
+
         services.AddSingleton<ICacheService, RedisCacheService>();
         services.AddSingleton<DistributedCacheEntryOptions>();
         services.AddTransient<GlobalExceptionHandlerMiddleware>();
+
+        return services;
+    }
+
+    private static IServiceCollection AddFileStorageProvider(this IServiceCollection services, IConfiguration configuration)
+    {
+        var provider = configuration.GetValue<string>("Storage:Provider") ?? "Local";
+
+        switch (provider)
+        {
+            case "S3":
+                var region = configuration.GetValue<string>("Storage:S3:Region") ?? "us-east-1";
+                services.AddSingleton<IAmazonS3>(_ => new AmazonS3Client(Amazon.RegionEndpoint.GetBySystemName(region)));
+                services.AddScoped<IFileStorageService, S3FileStorageService>();
+                break;
+            default:
+                services.AddScoped<IFileStorageService, LocalFileStorageService>();
+                break;
+        }
 
         return services;
     }

--- a/src/BitFinance.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BitFinance.API/Extensions/ServiceCollectionExtensions.cs
@@ -34,6 +34,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IBillDocumentService, BillDocumentService>();
         services.AddScoped<ICookieService, CookieService>();
 
+        services.AddSingleton<IValidateOptions<JwtSettings>, JwtSettingsValidator>();
+        services.AddOptions<JwtSettings>()
+            .Bind(configuration.GetSection(JwtSettings.SectionName))
+            .ValidateOnStart();
+
         services.AddSingleton<IValidateOptions<StorageSettings>, StorageSettingsValidator>();
         services.AddOptions<StorageSettings>()
             .Bind(configuration.GetSection(StorageSettings.SectionName))

--- a/src/BitFinance.API/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BitFinance.API/Extensions/ServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IExpensesRepository, ExpensesRepository>();
         services.AddScoped<IOrganizationInvitesRepository, OrganizationInvitesRepository>();
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
+        services.AddScoped<IBillDocumentsRepository, BillDocumentsRepository>();
 
         services.AddScoped<IUsersService, UsersService>();
         services.AddScoped<IBillsService, BillsService>();

--- a/src/BitFinance.API/Program.cs
+++ b/src/BitFinance.API/Program.cs
@@ -7,7 +7,7 @@ builder.AddAzureKeyVault();
 builder.Services.AddHttpOptions();
 builder.Services.AddJwtAuthentication(builder.Configuration);
 builder.Services.AddDatabaseContext(builder.Configuration);
-builder.Services.AddDependencyInjection();
+builder.Services.AddDependencyInjection(builder.Configuration);
 builder.Services.AddCaching(builder.Configuration);
 builder.Services.AddApiDocumentation();
 builder.Services.AddCustomHttpLogging();

--- a/src/BitFinance.API/Services/LocalFileStorageService.cs
+++ b/src/BitFinance.API/Services/LocalFileStorageService.cs
@@ -1,5 +1,7 @@
 using System.Security.Cryptography;
 using BitFinance.API.Services.Interfaces;
+using BitFinance.API.Settings;
+using Microsoft.Extensions.Options;
 
 namespace BitFinance.API.Services;
 
@@ -9,15 +11,16 @@ public class LocalFileStorageService : IFileStorageService
     private readonly ILogger<LocalFileStorageService> _logger;
 
     public LocalFileStorageService(
-        IConfiguration configuration,
+        IOptions<StorageSettings> settings,
         ILogger<LocalFileStorageService> logger)
     {
-        _basePath = string.IsNullOrWhiteSpace(configuration["Storage:LocalPath"]) 
+        var localPath = settings.Value.LocalPath;
+        _basePath = string.IsNullOrWhiteSpace(localPath)
             ? Path.Combine(Directory.GetCurrentDirectory(), "uploads")
-            : configuration["Storage:LocalPath"]!;
-        
+            : localPath;
+
         _logger = logger;
-        
+
         Directory.CreateDirectory(_basePath);
     }
     
@@ -107,7 +110,8 @@ public class LocalFileStorageService : IFileStorageService
 
     public Task<bool> FileExistsAsync(string storagePath)
     {
-        throw new NotImplementedException();
+        var fullPath = Path.Combine(_basePath, storagePath);
+        return Task.FromResult(File.Exists(fullPath));
     }
 
     public string GenerateUniqueFileName(string originalFileName)

--- a/src/BitFinance.API/Services/S3FileStorageService.cs
+++ b/src/BitFinance.API/Services/S3FileStorageService.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using System.Security.Cryptography;
+using Amazon.S3;
+using Amazon.S3.Model;
+using BitFinance.API.Services.Interfaces;
+using BitFinance.API.Settings;
+using Microsoft.Extensions.Options;
+
+namespace BitFinance.API.Services;
+
+public class S3FileStorageService : IFileStorageService
+{
+    private readonly IAmazonS3 _s3Client;
+    private readonly StorageSettings _settings;
+    private readonly ILogger<S3FileStorageService> _logger;
+
+    public S3FileStorageService(
+        IAmazonS3 s3Client,
+        IOptions<StorageSettings> settings,
+        ILogger<S3FileStorageService> logger)
+    {
+        _s3Client = s3Client;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public async Task<FileStorageResult> SaveFileAsync(Stream fileStream, string fileName, string contentType, Guid entityId, string subDirectory = "")
+    {
+        try
+        {
+            var uniqueFileName = GenerateUniqueFileName(fileName);
+            var key = BuildObjectKey(subDirectory, entityId, uniqueFileName);
+
+            using var sha256 = SHA256.Create();
+            using var memoryStream = new MemoryStream();
+
+            var buffer = new byte[8192];
+            int bytesRead;
+            long totalBytes = 0;
+
+            while ((bytesRead = await fileStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
+            {
+                await memoryStream.WriteAsync(buffer, 0, bytesRead);
+                sha256.TransformBlock(buffer, 0, bytesRead, null, 0);
+                totalBytes += bytesRead;
+            }
+
+            sha256.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+            var hash = Convert.ToBase64String(sha256.Hash!);
+
+            memoryStream.Position = 0;
+
+            var putRequest = new PutObjectRequest
+            {
+                BucketName = _settings.S3.BucketName,
+                Key = key,
+                InputStream = memoryStream,
+                ContentType = contentType
+            };
+
+            await _s3Client.PutObjectAsync(putRequest);
+
+            return new FileStorageResult
+            {
+                Success = true,
+                StoragePath = key,
+                FileName = uniqueFileName,
+                FileSizeInBytes = totalBytes,
+                FileHash = hash
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving file {FileName} to S3", fileName);
+            return new FileStorageResult
+            {
+                Success = false,
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
+    public async Task<Stream> GetFileAsync(string storagePath)
+    {
+        var response = await _s3Client.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = _settings.S3.BucketName,
+            Key = storagePath
+        });
+
+        return response.ResponseStream;
+    }
+
+    public async Task<bool> DeleteFileAsync(string storagePath)
+    {
+        try
+        {
+            var response = await _s3Client.DeleteObjectAsync(new DeleteObjectRequest
+            {
+                BucketName = _settings.S3.BucketName,
+                Key = storagePath
+            });
+
+            return response.HttpStatusCode == HttpStatusCode.NoContent;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting file {StoragePath} from S3", storagePath);
+            return false;
+        }
+    }
+
+    public async Task<bool> FileExistsAsync(string storagePath)
+    {
+        try
+        {
+            await _s3Client.GetObjectMetadataAsync(new GetObjectMetadataRequest
+            {
+                BucketName = _settings.S3.BucketName,
+                Key = storagePath
+            });
+
+            return true;
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
+    public string GenerateUniqueFileName(string originalFileName)
+    {
+        var extension = Path.GetExtension(originalFileName);
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(originalFileName);
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+        var guid = Guid.NewGuid().ToString("N")[..8];
+
+        return $"{fileNameWithoutExtension}_{timestamp}_{guid}{extension}";
+    }
+
+    private string BuildObjectKey(string subDirectory, Guid entityId, string fileName)
+    {
+        var parts = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(_settings.S3.Prefix))
+            parts.Add(_settings.S3.Prefix);
+
+        if (!string.IsNullOrWhiteSpace(subDirectory))
+            parts.Add(subDirectory);
+
+        parts.Add(DateTime.UtcNow.Year.ToString());
+        parts.Add(DateTime.UtcNow.Month.ToString("00"));
+        parts.Add(entityId.ToString());
+        parts.Add(fileName);
+
+        return string.Join("/", parts);
+    }
+}

--- a/src/BitFinance.API/Settings/JwtSettings.cs
+++ b/src/BitFinance.API/Settings/JwtSettings.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Options;
+
+namespace BitFinance.API.Settings;
+
+public class JwtSettings
+{
+    public const string SectionName = "Jwt";
+
+    public string Key { get; set; } = string.Empty;
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+    public int ExpirationInMinutes { get; set; } = 120;
+}
+
+public class JwtSettingsValidator : IValidateOptions<JwtSettings>
+{
+    public ValidateOptionsResult Validate(string? name, JwtSettings options)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(options.Key))
+            errors.Add("Jwt:Key is required.");
+
+        if (string.IsNullOrWhiteSpace(options.Issuer))
+            errors.Add("Jwt:Issuer is required.");
+
+        if (string.IsNullOrWhiteSpace(options.Audience))
+            errors.Add("Jwt:Audience is required.");
+
+        if (options.ExpirationInMinutes <= 0)
+            errors.Add("Jwt:ExpirationInMinutes must be greater than 0.");
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/BitFinance.API/Settings/StorageSettings.cs
+++ b/src/BitFinance.API/Settings/StorageSettings.cs
@@ -1,0 +1,65 @@
+using Microsoft.Extensions.Options;
+
+namespace BitFinance.API.Settings;
+
+public class StorageSettings
+{
+    public const string SectionName = "Storage";
+
+    public string Provider { get; set; } = "Local";
+    public string LocalPath { get; set; } = "./documents";
+    public int MaxFileSizeInMB { get; set; } = 10;
+    public string[] AllowedExtensions { get; set; } = [".pdf", ".jpg", ".jpeg", ".png", ".doc", ".docx"];
+    public S3Settings S3 { get; set; } = new();
+}
+
+public class S3Settings
+{
+    public string BucketName { get; set; } = string.Empty;
+    public string Region { get; set; } = "us-east-1";
+    public string Prefix { get; set; } = "documents";
+}
+
+public class StorageSettingsValidator : IValidateOptions<StorageSettings>
+{
+    private static readonly string[] ValidProviders = ["Local", "S3"];
+
+    public ValidateOptionsResult Validate(string? name, StorageSettings options)
+    {
+        var errors = new List<string>();
+
+        if (!ValidProviders.Contains(options.Provider))
+        {
+            errors.Add($"Storage:Provider '{options.Provider}' is invalid. Valid values: {string.Join(", ", ValidProviders)}.");
+        }
+
+        if (options.MaxFileSizeInMB <= 0)
+        {
+            errors.Add("Storage:MaxFileSizeInMB must be greater than 0.");
+        }
+
+        if (options.AllowedExtensions.Length == 0)
+        {
+            errors.Add("Storage:AllowedExtensions must contain at least one file extension.");
+        }
+
+        switch (options.Provider)
+        {
+            case "Local":
+                if (string.IsNullOrWhiteSpace(options.LocalPath))
+                    errors.Add("Storage:LocalPath is required when Provider is 'Local'.");
+                break;
+
+            case "S3":
+                if (string.IsNullOrWhiteSpace(options.S3.BucketName))
+                    errors.Add("Storage:S3:BucketName is required when Provider is 'S3'.");
+                if (string.IsNullOrWhiteSpace(options.S3.Region))
+                    errors.Add("Storage:S3:Region is required when Provider is 'S3'.");
+                break;
+        }
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/BitFinance.API/appsettings.json
+++ b/src/BitFinance.API/appsettings.json
@@ -18,9 +18,15 @@
     "AllowedOrigins": ["https://localhost:3000", "http://localhost:3000"]
   },
   "Storage": {
+    "Provider": "Local",
     "LocalPath": "./documents",
     "MaxFileSizeInMB": 10,
-    "AllowedExtensions": [".pdf", ".jpg", ".jpeg", ".png", ".doc", ".docx"]
+    "AllowedExtensions": [".pdf", ".jpg", ".jpeg", ".png", ".doc", ".docx"],
+    "S3": {
+      "BucketName": "",
+      "Region": "us-east-1",
+      "Prefix": "documents"
+    }
   },
   "Serilog":  {
     "MinimumLevel": {

--- a/src/BitFinance.Business/Enums/StorageProvider.cs
+++ b/src/BitFinance.Business/Enums/StorageProvider.cs
@@ -4,4 +4,5 @@ public enum StorageProvider
 {
     Local = 1,
     AzureBlobStorage = 2,
+    AmazonS3 = 3,
 }

--- a/src/BitFinance.Data/Repositories/BillDocumentsRepository.cs
+++ b/src/BitFinance.Data/Repositories/BillDocumentsRepository.cs
@@ -1,0 +1,61 @@
+using System.Linq.Expressions;
+using BitFinance.Business.Entities;
+using BitFinance.Data.Contexts;
+using BitFinance.Data.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace BitFinance.Data.Repositories;
+
+public class BillDocumentsRepository : IBillDocumentsRepository
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public BillDocumentsRepository(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<List<BillDocument>> GetAllAsync()
+    {
+        return await _dbContext.Set<BillDocument>()
+            .AsNoTracking()
+            .Where(d => d.DeletedAt == null)
+            .OrderByDescending(d => d.UploadedAt)
+            .ToListAsync();
+    }
+
+    public async Task<BillDocument?> GetByIdAsync(Guid id)
+    {
+        return await _dbContext.Set<BillDocument>()
+            .FirstOrDefaultAsync(d => d.Id == id && d.DeletedAt == null);
+    }
+
+    public async Task<BillDocument> CreateAsync(BillDocument entity)
+    {
+        _dbContext.Set<BillDocument>().Add(entity);
+        await _dbContext.SaveChangesAsync();
+        return entity;
+    }
+
+    public async Task UpdateAsync(BillDocument entity)
+    {
+        _dbContext.Set<BillDocument>().Update(entity);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public Task UpdateAsync(BillDocument entity, params Expression<Func<BillDocument, object>>[] properties)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task DeleteAsync(BillDocument entity)
+    {
+        _dbContext.Set<BillDocument>().Remove(entity);
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task SaveChangesAsync()
+    {
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/src/BitFinance.Data/Repositories/Interfaces/IBillDocumentsRepository.cs
+++ b/src/BitFinance.Data/Repositories/Interfaces/IBillDocumentsRepository.cs
@@ -1,0 +1,7 @@
+using BitFinance.Business.Entities;
+
+namespace BitFinance.Data.Repositories.Interfaces;
+
+public interface IBillDocumentsRepository : IRepository<BillDocument, Guid>
+{
+}


### PR DESCRIPTION
- Adds pluggable file storage via new Storage settings (Local default, S3 option) and implements S3FileStorageService (AWS SDK S3).
- Updates bill document upload/download flow to persist storage metadata (path/hash/provider) and support S3 object keys with prefix + date + entity id.
- Introduces IBillDocumentsRepository + BillDocumentsRepository and refactors BillDocumentService to use the repository instead of direct context access.
- Adds DELETE /api/v{version}/organizations/{organizationId}/bills/{billId}/documents/{documentId} endpoint.
- Refactors JWT configuration to use IOptions<JwtSettings> with startup validation (ValidateOnStart) to fail fast on misconfigured JWT settings.