### PR TITLE
feat!: remove soft deletes from entities

### DIFF
--- a/src/BitFinance.API/Controllers/BillsController.cs
+++ b/src/BitFinance.API/Controllers/BillsController.cs
@@ -220,7 +220,7 @@ public class BillsController : ControllerBase
             
             if (!isValidCategory || !isValidStatus) return UnprocessableEntity();
 
-            var bill = await _context.Bills.FirstOrDefaultAsync(b => b.Id == billId && b.DeletedAt == null);
+            var bill = await _context.Bills.FirstOrDefaultAsync(b => b.Id == billId);
 
             if (bill is null)
             {
@@ -271,7 +271,7 @@ public class BillsController : ControllerBase
     [HttpDelete]
     [Route("{billId:guid}")]
     [EndpointSummary("Delete a bill")]
-    [EndpointDescription("Soft-deletes a bill by setting its deleted timestamp.")]
+    [EndpointDescription("Deletes a bill and its associated documents.")]
     public async Task<ActionResult> DeleteBillById([FromRoute] Guid organizationId, Guid billId)
     {
         try
@@ -283,9 +283,9 @@ public class BillsController : ControllerBase
                 return NotFound();
             }
 
-            if (bill.DeletedAt is not null)
+            foreach (var document in bill.Documents)
             {
-                return BadRequest();
+                await _documentService.DeleteDocumentAsync(document.Id);
             }
 
             await _billsRepository.DeleteAsync(bill);

--- a/src/BitFinance.API/Controllers/ExpensesController.cs
+++ b/src/BitFinance.API/Controllers/ExpensesController.cs
@@ -207,7 +207,7 @@ public class ExpensesController : ControllerBase
     [HttpDelete]
     [Route("{expenseId:guid}")]
     [EndpointSummary("Delete an expense")]
-    [EndpointDescription("Soft-deletes an expense by setting its deleted timestamp.")]
+    [EndpointDescription("Deletes an expense.")]
     public async Task<ActionResult> DeleteExpenseById([FromRoute] Guid organizationId, Guid expenseId)
     {
         try
@@ -217,11 +217,6 @@ public class ExpensesController : ControllerBase
             if (expense is null)
             {
                 return NotFound();
-            }
-
-            if (expense.DeletedAt is not null)
-            {
-                return BadRequest();
             }
 
             await _expensesRepository.DeleteAsync(expense);

--- a/src/BitFinance.API/Controllers/OrganizationsController.cs
+++ b/src/BitFinance.API/Controllers/OrganizationsController.cs
@@ -99,7 +99,6 @@ public class OrganizationsController : ControllerBase
             Name = request.Name,
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = null,
-            DeletedAt = null,
         };
         
         organization.Members.Add(user);

--- a/src/BitFinance.API/Models/Response/GetOrganizationByIdResponse.cs
+++ b/src/BitFinance.API/Models/Response/GetOrganizationByIdResponse.cs
@@ -6,6 +6,5 @@ public class GetOrganizationByIdResponse
     public string Name { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
-    public DateTime? DeletedAt { get; set; }
     public List<UserResponseModel> Members { get; set; } = [];
 }

--- a/src/BitFinance.Business/Entities/Bill.cs
+++ b/src/BitFinance.Business/Entities/Bill.cs
@@ -14,7 +14,6 @@ public class Bill
     public DateTimeOffset? PaymentDate { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
-    public DateTime? DeletedAt { get; set; }
     public Guid OrganizationId { get; set; }
     public Organization Organization { get; set; } = null!;
     public ICollection<BillDocument> Documents { get; set; } = new List<BillDocument>();

--- a/src/BitFinance.Business/Entities/BillDocument.cs
+++ b/src/BitFinance.Business/Entities/BillDocument.cs
@@ -26,5 +26,4 @@ public class BillDocument
     // Audit fields
     public DateTime UploadedAt { get; set; }
     public Guid? UploadedByUserId { get; set; }
-    public DateTime? DeletedAt { get; set; }
 }

--- a/src/BitFinance.Business/Entities/Expense.cs
+++ b/src/BitFinance.Business/Entities/Expense.cs
@@ -12,8 +12,7 @@ public class Expense
     public DateTime OccurredAt { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
-    public DateTime? DeletedAt { get; set; }
-    
+
     public Guid OrganizationId { get; set; }
     public Organization Organization { get; set; } = null!;
     public string CreatedByUserId { get; set; } = null!;

--- a/src/BitFinance.Business/Entities/Organization.cs
+++ b/src/BitFinance.Business/Entities/Organization.cs
@@ -8,7 +8,6 @@ public class Organization
     public string Name { get; set; }
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
-    public DateTime? DeletedAt { get; set; }
     public string TimeZoneId { get; set; } = "America/Sao_Paulo";
     public ICollection<User> Members { get; set; } = new List<User>();
     public ICollection<Bill> Bills { get; set; } = new List<Bill>();

--- a/src/BitFinance.Business/Entities/UserSettings.cs
+++ b/src/BitFinance.Business/Entities/UserSettings.cs
@@ -7,6 +7,5 @@ public class UserSettings
     public string? TimeZoneId { get; set; } = "America/Sao_Paulo";
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime? UpdatedAt { get; set; }
-    public DateTime? DeletedAt { get; set; }
     public User User { get; set; }
 }

--- a/src/BitFinance.Data/Configurations/BillConfiguration.cs
+++ b/src/BitFinance.Data/Configurations/BillConfiguration.cs
@@ -58,11 +58,6 @@ public class BillConfiguration : IEntityTypeConfiguration<Bill>
             .HasColumnType("timestampz")
             .HasPrecision(3);
         
-        builder.Property(b => b.DeletedAt)
-            .HasColumnName("deleted_at")
-            .HasColumnType("timestampz")
-            .HasPrecision(3);
-
         builder.ToTable("bills");
     }
 }

--- a/src/BitFinance.Data/Configurations/ExpenseConfiguration.cs
+++ b/src/BitFinance.Data/Configurations/ExpenseConfiguration.cs
@@ -39,11 +39,6 @@ public class ExpenseConfiguration : IEntityTypeConfiguration<Expense>
             .HasColumnType("timestampz")
             .HasPrecision(3);
         
-        builder.Property(x => x.DeletedAt)
-            .HasColumnName("deleted_at")
-            .HasColumnType("timestampz")
-            .HasPrecision(3);
-        
         builder.HasOne(x => x.Organization)
             .WithMany(o => o.Expenses)
             .HasForeignKey(e => e.OrganizationId)
@@ -53,8 +48,6 @@ public class ExpenseConfiguration : IEntityTypeConfiguration<Expense>
             .WithMany()
             .HasForeignKey(x => x.CreatedByUserId)
             .OnDelete(DeleteBehavior.Restrict);
-        
-        builder.HasQueryFilter(e => e.DeletedAt == null);
         
         builder.ToTable("expenses");
     }

--- a/src/BitFinance.Data/Configurations/OrganizationConfiguration.cs
+++ b/src/BitFinance.Data/Configurations/OrganizationConfiguration.cs
@@ -23,11 +23,6 @@ public class OrganizationConfiguration : IEntityTypeConfiguration<Organization>
             .HasColumnType("timestampz")
             .HasPrecision(3);
         
-        builder.Property(o => o.DeletedAt)
-            .HasColumnName("deleted_at")
-            .HasColumnType("timestampz")
-            .HasPrecision(3);
-        
         builder.Property(o => o.TimeZoneId)
             .HasColumnName("timezone_id")
             .HasDefaultValue("America/Sao_Paulo")

--- a/src/BitFinance.Data/Contexts/ApplicationDbContext.cs
+++ b/src/BitFinance.Data/Contexts/ApplicationDbContext.cs
@@ -50,8 +50,5 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         }
         
         builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
-
-        // builder.Entity<Bill>().HasQueryFilter(x => x.OrganizationId == _contextOrganizationId);
-        // builder.Entity<Expense>().HasQueryFilter(x => x.OrganizationId == _contextOrganizationId);
     }
 }

--- a/src/BitFinance.Data/Migrations/20260221030246_RemoveSoftDelete.Designer.cs
+++ b/src/BitFinance.Data/Migrations/20260221030246_RemoveSoftDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BitFinance.Data.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BitFinance.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260221030246_RemoveSoftDelete")]
+    partial class RemoveSoftDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BitFinance.Data/Migrations/20260221030246_RemoveSoftDelete.cs
+++ b/src/BitFinance.Data/Migrations/20260221030246_RemoveSoftDelete.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BitFinance.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveSoftDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "user_settings");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "organizations");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "expenses");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "bills");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "bill_documents");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "user_settings",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "organizations",
+                type: "timestamp(3) with time zone",
+                precision: 3,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "expenses",
+                type: "timestamp(3) with time zone",
+                precision: 3,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "bills",
+                type: "timestamp(3) with time zone",
+                precision: 3,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "deleted_at",
+                table: "bill_documents",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+    }
+}

--- a/src/BitFinance.Data/Repositories/BillDocumentsRepository.cs
+++ b/src/BitFinance.Data/Repositories/BillDocumentsRepository.cs
@@ -19,7 +19,6 @@ public class BillDocumentsRepository : IBillDocumentsRepository
     {
         return await _dbContext.Set<BillDocument>()
             .AsNoTracking()
-            .Where(d => d.DeletedAt == null)
             .OrderByDescending(d => d.UploadedAt)
             .ToListAsync();
     }
@@ -27,7 +26,7 @@ public class BillDocumentsRepository : IBillDocumentsRepository
     public async Task<BillDocument?> GetByIdAsync(Guid id)
     {
         return await _dbContext.Set<BillDocument>()
-            .FirstOrDefaultAsync(d => d.Id == id && d.DeletedAt == null);
+            .FirstOrDefaultAsync(d => d.Id == id);
     }
 
     public async Task<BillDocument> CreateAsync(BillDocument entity)

--- a/src/BitFinance.Data/Repositories/ExpensesRepository.cs
+++ b/src/BitFinance.Data/Repositories/ExpensesRepository.cs
@@ -20,7 +20,6 @@ public class ExpensesRepository : IExpensesRepository
         return await _dbContext.Set<Expense>()
             .AsNoTracking()
             .Where(b => b.OrganizationId == organizationId)
-            .Where(b => b.DeletedAt == null)
             .ToListAsync();
     }
     
@@ -28,7 +27,6 @@ public class ExpensesRepository : IExpensesRepository
     {
         var query = _dbContext.Set<Expense>()
             .AsNoTracking()
-            .Where(b => b.DeletedAt == null)
             .Where(b => b.OrganizationId == organizationId);
 
         if (startDate.HasValue)
@@ -53,7 +51,7 @@ public class ExpensesRepository : IExpensesRepository
     {
         return await _dbContext.Set<Expense>()
             .AsNoTracking()
-            .Where(b => b.OrganizationId == organizationId && b.DeletedAt == null)
+            .Where(b => b.OrganizationId == organizationId)
             .OrderByDescending(e => e.OccurredAt)
             .ToListAsync();
     }
@@ -81,8 +79,7 @@ public class ExpensesRepository : IExpensesRepository
 
     public async Task DeleteAsync(Expense expense)
     {
-        expense.DeletedAt = DateTime.UtcNow;
-        _dbContext.Set<Expense>().Update(expense);
+        _dbContext.Set<Expense>().Remove(expense);
         await _dbContext.SaveChangesAsync();
     }
 

--- a/src/BitFinance.Data/Repositories/OrganizationsRepository.cs
+++ b/src/BitFinance.Data/Repositories/OrganizationsRepository.cs
@@ -19,7 +19,6 @@ public class OrganizationsRepository : IOrganizationsRepository
     {
         return await _dbContext.Set<Organization>()
             .AsNoTracking()
-            .Where(x => x.DeletedAt == null)
             .ToListAsync();
     }
     
@@ -27,7 +26,6 @@ public class OrganizationsRepository : IOrganizationsRepository
     {
         return await _dbContext.Set<Organization>()
             .AsNoTracking()
-            .Where(x => x.DeletedAt == null)
             .Where(x => x.Members.Any(m => m.Id == userId))
             .ToListAsync();
     }
@@ -35,7 +33,7 @@ public class OrganizationsRepository : IOrganizationsRepository
     public async Task<Organization?> GetByIdAsync(Guid id)
     {
         return await _dbContext.Set<Organization>()
-            .Where(x => x.Id == id && x.DeletedAt == null)
+            .Where(x => x.Id == id)
             .Include(x => x.Members)
             .FirstOrDefaultAsync();
     }
@@ -60,8 +58,7 @@ public class OrganizationsRepository : IOrganizationsRepository
 
     public async Task DeleteAsync(Organization organization)
     {
-        organization.DeletedAt = DateTime.UtcNow;
-        _dbContext.Set<Organization>().Update(organization);
+        _dbContext.Set<Organization>().Remove(organization);
         await _dbContext.SaveChangesAsync();
     }
     


### PR DESCRIPTION
- Removes soft-delete (DeletedAt) from Bill, BillDocument, Expense, Organization, UserSettings, and drops the deleted_at columns via EF migration 20260221030246_RemoveSoftDelete.
- Updates repositories/controllers to stop filtering on DeletedAt; deletes now hard-remove rows (and bill deletion also deletes associated documents).